### PR TITLE
PTKView - Fix wrong UX behavior

### DIFF
--- a/PaymentKit/PTKView.m
+++ b/PaymentKit/PTKView.m
@@ -439,8 +439,13 @@ static NSString *const kPTKOldLocalizedStringsTableName = @"STPaymentLocalizable
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)replacementString
 {
-    textField.textColor = self.customFontColor;
-    textField.font = self.customFont;
+    if (self.customFontColor) {
+        textField.textColor = self.customFontColor;
+    }
+    
+    if (self.customFont) {
+        textField.font = self.customFont;
+    }
     
     if ([textField isEqual:self.cardNumberField]) {
         return [self cardNumberFieldShouldChangeCharactersInRange:range replacementString:replacementString];


### PR DESCRIPTION
Fix wrong behavior when an user input a wrong credit card number and type another char. 
It should remain the same after the attempt of adding a char (error mode => textColor = Red).
